### PR TITLE
Saving chemicals in a collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 You can use this package to parse SigmaBAM files in openBIS. There are two resources used for automating the parsing of such files:
 
-1. Using the [_marimo_](https://marimo.io/) tutorial from `tutorials/parser_tutorial.py`. This tutorial uses the parser class defined in `src/sigmabam2openbis/parser.py` and the [`bam-masterdata`](https://github.com/BAMresearch/bam-masterdata) parser infrastructure. **We recommend using this tutorial**.
+1. Using the Python script in  `tutorials/parser_tutorial.py`. This script uses the parser class defined in `src/sigmabam2openbis/parser.py` and the [`bam-masterdata`](https://github.com/BAMresearch/bam-masterdata) parser infrastructure. **We recommend using this tutorial**. To run it, after setting up your environment (see below), run in the terminal `python tutorials/parser_script.py`.
 2. Using the _Jupyter notebook_ from `tutorials/chemical_data_inventory_openbis_mapper_1_0.ipynb`. This tutorial uses [PyBIS](https://pypi.org/project/pybis/).
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ license = { file = "LICENSE" }
 dependencies = [
   "pybis~=1.37.1rc4",
   "pandas",
-  "bam-masterdata>=0.8.2",
+  "bam-masterdata>=0.8.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
I added some functionalities in the new `bam-masterdata==0.8.4` version. Now, COLLECTION is the default when using `run_parser`. You can also set up `run_parser(..., collection_type="DEFAULT_EXPERIMENT")` to change the collection type where to store the objects.