### PR TITLE
Handle invalid BAM locations with fallback and log warnings

### DIFF
--- a/src/sigmabam2openbis/parser.py
+++ b/src/sigmabam2openbis/parser.py
@@ -131,19 +131,29 @@ class SigmaBAM2OpenBISParser(AbstractParser):
                             f"Umgang-Id {umgang_id}. Please, check the excel."
                         )
 
-                # Complete BAM location
+                #Complete BAM location
                 bam_location_complete = []
                 for col in ["Liegenschaft", "Haus", "Etage", "Raum-Nr"]:
                     val = self.get_value_as_str(chemical_row.get(col))
                     if not val:
                         logger.warning(
-                            f"Missing value for BAM location column '{col}'"
-                            f"Umgang-Id {umgang_id}. Please, check the excel."
+                        f"Missing value for BAM location column '{col}' in row with Umgang-Id {umgang_id}"
                         )
                         continue
                     bam_location_complete.append(val)
                 if bam_location_complete:
-                    chemical.bam_location_complete = "_".join(bam_location_complete)
+                    location_str = "_".join(bam_location_complete)
+                    try:
+                        # test assignment to catch vocabulary errors
+                        chemical.bam_location_complete = location_str
+                    except ValueError:
+                        fallback = "FB_80_-1_000"
+                        logger.warning(
+                    f"Invalid BAM location '{location_str}'"
+                    f"for Umgang-Id {umgang_id}"
+                    f"Replacing with fallback '{fallback}'."
+                    )
+                        chemical.bam_location_complete = fallback
 
                 # Adding chemicals to the collection
                 collection.add(chemical)

--- a/src/sigmabam2openbis/parser.py
+++ b/src/sigmabam2openbis/parser.py
@@ -131,13 +131,13 @@ class SigmaBAM2OpenBISParser(AbstractParser):
                             f"Umgang-Id {umgang_id}. Please, check the excel."
                         )
 
-                #Complete BAM location
+                # Complete BAM location
                 bam_location_complete = []
                 for col in ["Liegenschaft", "Haus", "Etage", "Raum-Nr"]:
                     val = self.get_value_as_str(chemical_row.get(col))
                     if not val:
                         logger.warning(
-                        f"Missing value for BAM location column '{col}' in row with Umgang-Id {umgang_id}"
+                            f"Missing value for BAM location column '{col}' in row with Umgang-Id {umgang_id}"
                         )
                         continue
                     bam_location_complete.append(val)
@@ -149,10 +149,10 @@ class SigmaBAM2OpenBISParser(AbstractParser):
                     except ValueError:
                         fallback = "FB_80_-1_000"
                         logger.warning(
-                    f"Invalid BAM location '{location_str}'"
-                    f"for Umgang-Id {umgang_id}"
-                    f"Replacing with fallback '{fallback}'."
-                    )
+                            f"Invalid BAM location '{location_str}'"
+                            f"for Umgang-Id {umgang_id}"
+                            f"Replacing with fallback '{fallback}'."
+                        )
                         chemical.bam_location_complete = fallback
 
                 # Adding chemicals to the collection


### PR DESCRIPTION
This PR fixes issue #7 by adding a fallback mechanism for invalid BAM locations.
- Logs warnings when a location is not recognized
- Ensures processing continues without crashing

Closes #7